### PR TITLE
Fixes Desert Poopcoder lazy copypasta that breaks cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1140,7 +1140,7 @@
 					/obj/item/vending_refill/medical,
 					/obj/item/vending_refill/medical)
 	crate_name = "medical vending crate"
-/datum/supply_pack/medical/firstaidbruises
+/datum/supply_pack/medical/posibrain
 	name = "Posibrain Crate"
 	desc = "Contains a posibrain, used in robotic contruction."
 	cost = 2500


### PR DESCRIPTION
some dumbbutt forgot to change 'bruisefirstaidkit' to 'posibrain', screwing over the bruise kit order

this changes literally one word to make it work correctly


## Changelog (necessary)
:cl:
fix: Brute Medkits should no longer be overwritten by posibrains in the C.A.S.P.
/:cl:
