### PR TITLE
Adds diluted stimpak fluid

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1722,3 +1722,38 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 		H.vomit(10)
 	..()
 	. = 1
+	
+/datum/reagent/medicine/diluted_stimpak
+	name = "Diluted Stimpak Fluid"
+	id = "diluted_stimpak"
+	description = "Slowly heals damage when injected. Deals minor toxin damage if ingested."
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	taste_description = "watery metal"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 30
+
+/datum/reagent/medicine/diluted_stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	if(iscarbon(M) && M.stat != DEAD)
+		if(method in list(INGEST, VAPOR))
+			M.adjustToxLoss(3.75*reac_volume) //increased from 0.5*reac_volume, which was amusingly low since stimpak heals toxins. now a pill at safe max crits and then heals back up to low health within a few seconds
+			if(show_message)
+				to_chat(M, "<span class='warning'>You don't feel so good...</span>")
+	..()
+
+/datum/reagent/medicine/diluted_stimpak/on_mob_life(mob/living/carbon/M)
+	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0 && M.getToxLoss() == 0)
+		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
+	M.adjustBruteLoss(-2*REM, 0)
+	M.adjustFireLoss(-2*REM, 0)
+	M.adjustToxLoss(-0.5*REM, 0)
+	M.AdjustStun(-2, 0)
+	M.AdjustKnockdown(-2, 0)
+	M.adjustStaminaLoss(-1*REM, 0)
+	..()
+
+/datum/reagent/medicine/diluted_stimpak/overdose_process(mob/living/M)
+	M.adjustToxLoss(5*REM, 0)
+	M.adjustOxyLoss(8*REM, 0)
+	..()
+	. = 1

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -253,5 +253,13 @@
 	results = list("stimpak" = 2)
 	required_reagents = list("blood" = 2, "spaceacillin" = 3)
 	required_temp = 300
+	
+/datum/chemical_reaction/dilutedstimpak
+	name = "Diluted Stimpak Fluid"
+	id = "stimpakdilution"
+	results = list("diluted_stimpak" = 2)
+	required_reagents = list("stimpak" = 1, "water" = 1)
+	required_temp = 375
+
 
 


### PR DESCRIPTION
## Description
Adds a new chemical called 'Diluted Stimpak Fluid'. At the moment, it doesn't spawn in the wasteland naturally, and must be created via chemistry.

You can make diluted stim-fluid with the following recipe;
1u Stimpak Fluid (normal)
1u Water
Heat to 375 Kelvin

This will create 2u of diluted stim-fluid. Diluted stim-fluid is identical to standard stim-fluid, but heals at half the speed of a standard stimpak. Good for dealing with minor injuries, or if medicine is scarce.

## Changelog (necessary)
:cl:
add: Adds 'Diluted Stimpak Fluid', which can be made with 1u stimpak-fluid + 1u water + heated to 375K; acts as a weaker, cheaper version of normal stimpak fluid
/:cl:
