### PR TITLE
Job requirement changes round two

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -440,7 +440,7 @@ Senior Scribe
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Head Scribe"
 	selection_color = "#95a5a6"
-	exp_requirements = 600
+	exp_requirements = 180
 	outfit = /datum/outfit/job/bos/f13seniorscribe
 
 	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
@@ -685,7 +685,7 @@ Initiate
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the scribes, knights, or Paladins"
 	selection_color = "#95a5a6"
-	exp_requirements = 1800
+	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 
 	loadout_options = list(

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -193,7 +193,7 @@ Mayor
 	supervisors = "the sheriff and the mayor"
 	description = "Prospecting is a complicated business, some call it scrounging or looting but there is more to it then sifting through rubble - few can boast the skills you posess in mining and delving through the ruins of pre-war America. Not many survive this line of business and the pay has always been uncertain, but perhaps today you'll find strike gold."
 	selection_color = "#dcba97"
-	exp_requirements = 180
+	exp_requirements = 120
 	exp_type = EXP_TYPE_DEN
 
 	outfit = /datum/outfit/job/den/f13prospector
@@ -237,7 +237,7 @@ Mayor
 	supervisors = "the sheriff and the mayor"
 	description = "Handy with a scalpel and a scanner, your expertise in the practice of medicine makes you an indespesnbile asset to the town. How you play your trade and whether it be for profit or the fortune of others rests entirely upon your shoulders."
 	selection_color = "#dcba97"
-	exp_requirements = 540
+	exp_requirements = 300
 	exp_type = EXP_TYPE_DEN
 
 	outfit = /datum/outfit/job/den/f13dendoc

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -544,7 +544,7 @@ Recruit Legionary
 	spawn_positions = 3
 	description = "You have recently come of age or been inducted into Caesar's Legion. You have absolutely no training, and are expected to follow every whim of the Decanii and your Centurion."
 	supervisors = "the Decani and Centurion"
-	exp_requirements = 300
+	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13recleg
@@ -700,7 +700,7 @@ Camp Follower
 	spawn_positions = 4
 	description = "You answer to any member of the Legion, but take orders directly from the Auxilia around the camp. Working as a Camp Follower for the Centuria, you bear the great honor of supporting Caesar's Army in its conquest of the Mojave in whatever capacity required from those whom you serve. You perform any tasks required of you, for you know how to serve the Legion well."
 	supervisors = "the entire legion"
-	exp_requirements = 300
+	exp_requirements = 60
 
 	outfit = /datum/outfit/job/CaesarsLegion/f13campfollower
 
@@ -767,7 +767,8 @@ Slave
 	spawn_positions = 4
 	description = "You answer to any member of the Legion, but take orders directly from the Auxilia around the camp. You are to the point where you have been broken in as a slave and most slaves will no longer consider escaping as an option."
 	supervisors = "the entire legion, but mostly the Slavemaster"
-	exp_requirements = 300
+	exp_requirements = 30
+	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/CaesarsLegion/slave
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -466,7 +466,7 @@ Trooper
 	description = "You answer to everyone above you in the chain of command, taking orders from your Sergeant directly and obeying all commands given by officers such as the Lieutenant and Captain."
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
-	exp_requirements = 300
+	exp_requirements = 120
 
 	outfit = /datum/outfit/job/ncr/f13trooper
 
@@ -517,7 +517,7 @@ Recruit
 	description = "You are a noncombatant member of the NCR assigned the vital duty of helping them with cooking, farming, mining, and other menial tasks. While you have been to basic training, it was rushed and hardly prepared you for the horrors of war. Your sidearm is to be used in your own defense, only."
 	supervisors = "everyone in the NCR"
 	selection_color = "#fff5cc"
-	exp_requirements = 300
+	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/ncr/f13recruit
@@ -582,7 +582,7 @@ Recruit
 	description = "As an NCR Citizen, you may believe that the potential for fortune out west has dried up and that the frontier holds abundant opportunities for you to encroach and take advantage of. Surrounded by the relative safety of the Republic, you are responsible for being a part of the cities community and maintaining the facilities within it in any capacity which will aid the greater good. You may correspond with the Administrator or other NCR leadership to help them achieve goals, or pursue your own individual goals as an independent agent of the NCR.."
 	supervisors = "NCR Administrator"
 	selection_color = "#fff5cc"
-	exp_requirements = 300
+	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/ncr/f13ncrcitizen
 	loadout_options = list(

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -423,7 +423,7 @@ Vault Engineer
 	selection_color = "#ddffdd"
 	access = list()			//See /datum/job/vault/assistant/get_access()
 	minimal_access = list()	//See /datum/job/vault/assistant/get_access()
-	exp_requirements = 900
+	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/vault/f13vaultDweller


### PR DESCRIPTION
## Description
Rebalance of entry-level faction jobs.

## Motivation and Context
Job requirements too high.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Changelog (necessary)
:cl:
balance: BoS Senior Scribe BoS playtime requirement lowered to 3 hours
balance: BoS Initiate general playtime requirement lowered to 5 hours
balance: Oasis Prospector Oasis playtime requirement lowered to 2 hours
balance: Oasis Doctor Oasis playtime requirement lowered to 5 hours
balance: Legion Recruit Legionary general playtime requirement lowered to 2 hours
balance: Legion Camp Follower Legion playtime requirement lowered to 1 hour
tweak: Legion Slave playtime requirement changed to general playtime
balance: Legion Slave general playtime requirement lowered to 30 minutes
balance: NCR Citizen general playtime requirement lowered to 1 hour
balance: NCR Assistant general playtime requirement lowered to 1 hour
balance: NCR Trooper NCR playtime requirement lowered to 2 hours
balance: Vault Vault Dweller general playtime requirement lowered to 1 hour
/:cl:
