### PR TITLE
Certain wasteland drugs are now mixable

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -33,3 +33,25 @@
 	id = "aranesp"
 	results = list("aranesp" = 3)
 	required_reagents = list("epinephrine" = 1, "atropine" = 1, "morphine" = 1)
+	
+/datum/chemical_reaction/jet
+	name = "Jet"
+	id = "jet"
+	results = list("jet" = 1)
+	required_reagents = list("milk" = 1, "ammonia" = 1)
+	mix_message = "The mixture bubbles, fumes wafting into the air."
+	required_temp = 374
+	
+/datum/chemical_reaction/turbo
+	name = "Turbo"
+	id = "turbo"
+	results = list("turbo" = 1)
+	required_reagents = list("jet" = 1, "hydrogen" = 2, "welding_fuel" = 3)
+	required_temp = 374
+	
+/datum/chemical_reaction/psycho
+	name = "Psycho Fluid"
+	id = "psycho"
+	results = list("psycho" = 1)
+	required_reagents = list("sacid" = 1, "silicon" = 1, "stimpak" = 1)
+	mix_message = "The fluid froths and foams, turning a blood-red color."


### PR DESCRIPTION
## Description
You can now mix up Jet, Turbo, and Psycho in chemistry. They cost less than doing it by hand, so that's cool.

Chemistry can actually make drugs. Y'know, with chemistry.

Jet: 1u Milk + 1u Ammonia + 374K Temp = 1u Jet
Turbo: 1u Jet + 2u Hydrogen + 3u Welding Fuel + 374K Temp = 1u Turbo
Psycho: 1u Silicon + 1u Sulphuric Acid + 1u Stimpak Fluid = 1u Psycho

## Changelog (necessary)
:cl:
add: Chemistry can now make Jet, Turbo, and Psycho.
/:cl:
