### PR TITLE
Adds a new 'Ultra Stimpak'

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1757,3 +1757,32 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	M.adjustOxyLoss(8*REM, 0)
 	..()
 	. = 1
+	
+/datum/reagent/medicine/ultra_stimpak
+	name = "Experimental Stimpak Fluid"
+	id = "ultra_stimpak"
+	description = "An experimental, pre-war chemical soup that cannot be replicated with post-war tools. Extremely potent, but has a painfully low overdose threshold."
+	reagent_state = LIQUID
+	color = "#e50d0d"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 10
+
+/datum/reagent/medicine/ultra_stimpak/on_mob_life(mob/living/M)
+	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0 && M.getToxLoss() == 0 && M.getOxyLoss() == 0)
+		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
+	if(!M.reagents.has_reagent("healing_poultice") && !M.reagents.has_reagent("stimpak") && !M.reagents.has_reagent("healing_powder")) // We don't want these healing items to stack, so we only apply the healing if these chems aren't found. We only check for the less powerful chems, so the least powerful one always heals.
+		M.adjustBruteLoss(-12*REM)
+		M.adjustFireLoss(-12*REM)
+		M.adjustOxyLoss(-4*REM)
+		M.adjustToxLoss(-4*REM, 0)
+		M.AdjustStun(-15, 0)
+		M.AdjustKnockdown(-15, 0)
+		M.adjustStaminaLoss(-6*REM, 0)
+		. = 1
+	..()
+
+/datum/reagent/medicine/ultra_stimpak/overdose_process(mob/living/M)
+	M.adjustToxLoss(12*REM, 0)
+	M.adjustOxyLoss(15*REM, 0)
+	..()
+	. = 1

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -222,3 +222,10 @@
 	icon_state = "rustedstimpakpen"
 	amount_per_transfer_from_this = 10
 	list_reagents = list("diluted_stimpak" = 10)
+	
+/obj/item/reagent_containers/hypospray/medipen/stimpak/ultra
+	name = "ultra stimpak"
+	desc = "A high-tech delivery system loaded with a powerful mixture containing numerous medicines that rapidly heal even the most mortal of wounds."
+	icon_state = "ultrastimpakpen"
+	amount_per_transfer_from_this = 10
+	list_reagents = list("ultra_stimpak" = 10)


### PR DESCRIPTION
## Description
An extremely potent (and currently unobtainable) 'ultra stimpak' now exists.

Heals twice as fast as a Super Stimpak, but will OD if you take more than 10u (aka, more than one stim at a time)

Sprites already existed for a ultra stim, so I said 'Why not?' and fully implemented it. Can't be found outside of admin spawns, atm

## Changelog (necessary)
:cl:
add: Rumors about an 'Ultra Stimpak', a stim twice as powerful as a Super Stimpak, being hidden in the depths of admemery are beginning to circulate..
/:cl:
