### PR TITLE
Vaults no longer get OP medical gear roundstart

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -423,10 +423,8 @@
 	lootcount = 1
 
 	loot = list(
-				/obj/item/gun/medbeam,
-				/obj/item/defibrillator/compact/combat/loaded,
-				/obj/item/reagent_containers/hypospray/combat,
-				/obj/item/clothing/glasses/hud/health/night,
+				/obj/item/defibrillator,
+				/obj/item/clothing/glasses/hud/health,
 				/obj/item/disk/surgery/revival
 				)
 


### PR DESCRIPTION
## Description
Vaults used to get a combat defib (the ones nukies get), a night vision medhud, a combat hypospray (again, one that heals like 20 of all damage types per tick and is given to nukies), and a freakin' medibeam gun.

Yeah, no. This removes the medibeam and combat spray from their pool, and replaces the NV with a normal medhud. They get a normal defib instead of a combat one.

Because they already get RND, Cargo, Hydroponics, Security+Armory, Pip-boys, tech knowledge, Chemistry, and an AI. They really don't need overpowered medical gear, too.

## Changelog (necessary)
:cl:
balance: Vault-Tec has replaced some of their standard-issue medical gear with less overpowered variants. No more medibeam or combat hypospray, and normal defibs and medhuds. Sorry, powergamers!
/:cl:
